### PR TITLE
Change to distribute as PYPI package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,9 @@ tmp/
 test/resources/lrs_properties.py
 
 # release
+build
 dist
-tincan.egg-info/
+*.egg-info/
 
 # wild
 todo.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,15 @@
 language: python
 python:
-  - "2.7"
+  - "3.5"
 install: easy_install aniso8601 pytz
 before_script:
   - cd test
   - cp resources/lrs_properties.py.travis-ci resources/lrs_properties.py
 script: python main.py
+
+deploy:
+  provider: pypi
+  user: edx
+  distributions: sdist bdist_wheel
+  on:
+    tags: true

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,16 @@
 from setuptools import setup
 
 setup(
-    name='tincan',
+    name='edx-tincan-py35',
     packages=[
         'tincan',
         'tincan/conversions',
         'tincan/documents',
     ],
-    version='0.0.5.py.35',
-    description='A Python library for implementing Tin Can API.',
-    author='Rustici Software',
-    author_email='mailto:support+tincanpython@tincanapi.com',
-    maintainer='Brian J. Miller',
+    version='0.0.5',
+    description='A Python 3 library for implementing Tin Can API.',
+    author='edX',
+    author_email='oscm@edx.org',
     maintainer_email='mailto:brian.miller@tincanapi.com',
     url='http://rusticisoftware.github.io/TinCanPython/',
     license='Apache License 2.0',


### PR DESCRIPTION
This PR has changes to distribute our fork of TinCan API as PYPI package at the time of release tag creation.